### PR TITLE
fix: 关注页解码崩溃 + 播放历史跨端同步

### DIFF
--- a/BilibiliLive/Component/Video/Plugins/BVideoPlayPlugin.swift
+++ b/BilibiliLive/Component/Video/Plugins/BVideoPlayPlugin.swift
@@ -6,18 +6,33 @@
 //
 
 import AVKit
+import UIKit
 
 class BVideoPlayPlugin: NSObject, CommonPlayerPlugin {
     private weak var playerVC: AVPlayerViewController?
     private var playerDelegate: BilibiliVideoResourceLoaderDelegate?
     private let playData: PlayerDetailData
 
+    // 历史进度上报：此前只在 playerDidDismiss 上报一次且 fire-and-forget，Apple TV 用户
+    // 常直接后台/杀进程而非优雅退出播放器，弱网下单次上报还会静默失败，导致手机端看不到
+    // ATV 观看记录。改为播放中周期性心跳 + 关键生命周期节点各 flush 一次。
+    private var historyReportObserver: Any?
+    private weak var reportPlayer: AVPlayer?
+    private var lastReportedTime = -1
+
     init(detailData: PlayerDetailData) {
         playData = detailData
     }
 
+    deinit {
+        stopHistoryReporting()
+        NotificationCenter.default.removeObserver(self)
+    }
+
     func playerDidLoad(playerVC: AVPlayerViewController) {
         self.playerVC = playerVC
+        NotificationCenter.default.addObserver(self, selector: #selector(appDidEnterBackground),
+                                               name: UIApplication.didEnterBackgroundNotification, object: nil)
         playerVC.player = nil
         playerVC.appliesPreferredDisplayCriteriaAutomatically = Settings.contentMatch
         Task {
@@ -47,9 +62,68 @@ class BVideoPlayPlugin: NSObject, CommonPlayerPlugin {
         playerVC?.player?.currentItem?.preferredPeakBitRate = bps
     }
 
+    // 播放器可用即开始周期心跳；换集/切码率会触发 playerDidCleanUp(旧 player) 再
+    // playerDidChange(新 player)，observer 随之重建，所以这里统一在 change 里启动。
+    func playerDidChange(player: AVPlayer) {
+        startHistoryReporting(player: player)
+    }
+
+    func playerDidPause(player: AVPlayer) {
+        flushHistory(player: player, reason: "pause")
+    }
+
+    func playerDidEnd(player: AVPlayer) {
+        flushHistory(player: player, reason: "end")
+    }
+
+    // 连续播放切集 / 切清晰度：旧 player 清理前 flush 最终进度，避免上一集漏报。
+    // 关键：切集时新插件 playerDidLoad 会把 playerVC.player 置 nil，KVO 的 cleanup 会
+    // 发给当前 active plugins（可能是新插件），若不校验就会用新集 playData 上报旧 player
+    // 时间，直接污染跨端历史。只处理属于自己的 player。
+    func playerDidCleanUp(player: AVPlayer) {
+        guard player === reportPlayer else { return }
+        flushHistory(player: player, reason: "cleanup")
+        stopHistoryReporting()
+        lastReportedTime = -1
+    }
+
     func playerDidDismiss(playerVC: AVPlayerViewController) {
-        guard let currentTime = playerVC.player?.currentTime().seconds, currentTime > 0 else { return }
-        WebRequest.reportWatchHistory(aid: playData.aid, cid: playData.cid, currentTime: Int(currentTime), epid: playData.epid, seasonId: playData.seasonId, isBangumi: playData.isBangumi)
+        flushHistory(player: playerVC.player, reason: "dismiss")
+        stopHistoryReporting()
+    }
+
+    @objc private func appDidEnterBackground() {
+        // Home / 上划杀进程前的最后一次机会补报，覆盖用户不优雅退出播放器的场景。
+        // 只用自己的 reportPlayer，避免回退到 playerVC.player 时误报别的插件的 player。
+        flushHistory(player: reportPlayer, reason: "background")
+    }
+
+    private func startHistoryReporting(player: AVPlayer) {
+        stopHistoryReporting()
+        reportPlayer = player
+        // 每 15s 上报一次当前进度（对齐 B站官方客户端的周期心跳），保证跨端可靠同步。
+        historyReportObserver = player.addPeriodicTimeObserver(
+            forInterval: CMTime(seconds: 15, preferredTimescale: 1), queue: .main
+        ) { [weak self] _ in
+            self?.flushHistory(player: self?.reportPlayer, reason: "heartbeat")
+        }
+    }
+
+    private func stopHistoryReporting() {
+        if let historyReportObserver, let reportPlayer {
+            reportPlayer.removeTimeObserver(historyReportObserver)
+        }
+        historyReportObserver = nil
+        reportPlayer = nil
+    }
+
+    private func flushHistory(player: AVPlayer?, reason: String) {
+        guard let seconds = player?.currentTime().seconds, seconds.isFinite, seconds > 0 else { return }
+        let t = Int(seconds)
+        if t == lastReportedTime { return } // 同一秒不重复上报
+        lastReportedTime = t
+        Logger.debug("[History] flush(\(reason)) aid=\(playData.aid) t=\(t)")
+        WebRequest.reportWatchHistory(aid: playData.aid, cid: playData.cid, currentTime: t, epid: playData.epid, seasonId: playData.seasonId, isBangumi: playData.isBangumi)
     }
 
     @MainActor

--- a/BilibiliLive/Component/Video/VideoDetailViewController.swift
+++ b/BilibiliLive/Component/Video/VideoDetailViewController.swift
@@ -392,19 +392,20 @@ class VideoDetailViewController: UIViewController {
 
     @IBAction func actionPlay(_ sender: Any) {
         Logger.info("[VideoDetail] actionPlay: aid=\(aid), cid=\(cid), epid=\(epid), isBangumi=\(isBangumi)")
-        let player = VideoPlayerViewController(playInfo: PlayInfo(aid: aid, cid: cid, epid: epid, isBangumi: isBangumi))
+        let player = VideoPlayerViewController(playInfo: PlayInfo(aid: aid, cid: cid, epid: epid, seasonId: isBangumi ? seasonId : nil, isBangumi: isBangumi))
         player.data = data
 
         // 优先使用分P列表作为播放序列
         if pages.count > 1, let index = pages.firstIndex(where: { $0.cid == cid }) {
-            let seq = pages.dropFirst(index).map({ PlayInfo(aid: aid, cid: $0.cid, epid: $0.epid, isBangumi: isBangumi) })
+            // 番剧每集 aid 取 $0.page（与分页点击路径一致），否则续集会串到当前集 aid。
+            let seq = pages.dropFirst(index).map({ PlayInfo(aid: isBangumi ? $0.page : aid, cid: $0.cid, epid: $0.epid, seasonId: isBangumi ? seasonId : nil, isBangumi: isBangumi) })
             if seq.count > 0 {
                 let nextProvider = VideoNextProvider(seq: seq)
                 player.nextProvider = nextProvider
             }
         } else if let related = data?.Related, related.count > 0 {
             // 如果没有多分P，使用推荐视频作为播放序列
-            var seq = [PlayInfo(aid: aid, cid: cid, epid: epid, isBangumi: isBangumi)]
+            var seq = [PlayInfo(aid: aid, cid: cid, epid: epid, seasonId: isBangumi ? seasonId : nil, isBangumi: isBangumi)]
             seq.append(contentsOf: related.map({ PlayInfo(aid: $0.aid, cid: $0.cid) }))
             let nextProvider = VideoNextProvider(seq: seq)
             player.nextProvider = nextProvider
@@ -501,7 +502,9 @@ extension VideoDetailViewController: UICollectionViewDelegate {
             let player = VideoPlayerViewController(playInfo: PlayInfo(aid: isBangumi ? page.page : aid, cid: page.cid, epid: page.epid, seasonId: isBangumi ? seasonId : nil, isBangumi: isBangumi))
             player.data = isBangumi ? nil : data
 
-            let seq = pages.dropFirst(indexPath.item).map({ PlayInfo(aid: aid, cid: $0.cid, seasonId: isBangumi ? seasonId : nil, isBangumi: isBangumi) })
+            // 与上面单播构造保持一致：番剧每集 aid 取 $0.page 并带上 $0.epid，
+            // 否则连续播放的番剧续集会串号或缺 epid，导致历史上报错乱。
+            let seq = pages.dropFirst(indexPath.item).map({ PlayInfo(aid: isBangumi ? $0.page : aid, cid: $0.cid, epid: $0.epid, seasonId: isBangumi ? seasonId : nil, isBangumi: isBangumi) })
             if seq.count > 0 {
                 let nextProvider = VideoNextProvider(seq: seq)
                 player.nextProvider = nextProvider

--- a/BilibiliLive/Module/ViewController/FollowsViewController.swift
+++ b/BilibiliLive/Module/ViewController/FollowsViewController.swift
@@ -29,6 +29,12 @@ class FollowsViewController: StandardVideoCollectionViewController<DynamicFeedDa
 
     override func goDetail(with feed: DynamicFeedData) {
         let epid = feed.modules.module_dynamic.major?.pgc?.epid
+        // 纯 PGC 动态（aid=0）走 epid 详情，避免用 aid=0 请求详情页拿不到内容。
+        if feed.aid == 0, let epid, epid > 0 {
+            let detailVC = VideoDetailViewController.create(epid: epid)
+            detailVC.present(from: self)
+            return
+        }
         let detailVC = VideoDetailViewController.create(aid: feed.aid, cid: feed.cid, epid: epid)
         detailVC.present(from: self)
     }
@@ -42,18 +48,64 @@ extension WebRequest {
         let update_baseline: String
         let has_more: Bool
         var videoFeeds: [DynamicFeedData] {
+            // 只保留可跳转的：普通视频(aid>0) 或有有效 epid 的番剧动态。
+            // epid 变可选后，pgc!=nil 但 epid=nil 的动态点了会用 aid=0 请求详情，直接过滤掉。
             return items
-                .filter({ $0.aid != 0 || $0.modules.module_dynamic.major?.pgc != nil })
+                .filter({ $0.aid != 0 || ($0.modules.module_dynamic.major?.pgc?.epid ?? 0) > 0 })
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case items, offset, update_num, update_baseline, has_more
+        }
+
+        // 关注动态流是异构数据，单条脏数据（epid/字段类型不符、缺字段）不应让整页
+        // 解码失败导致关注 tab 报错。逐条容错跳过坏项，顶层字段全部柔性解码。
+        private struct LossyItem: Decodable {
+            let value: DynamicFeedData?
+            init(from decoder: Decoder) throws {
+                value = try? DynamicFeedData(from: decoder)
+            }
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            let lossy = (try? container.decode([LossyItem].self, forKey: .items)) ?? []
+            let decoded = lossy.compactMap { $0.value }
+            let raw = lossy.count
+            if decoded.count < raw {
+                Logger.warn("[Follows] skipped \(raw - decoded.count)/\(raw) undecodable dynamic items")
+            }
+            items = decoded
+            if let s = try? container.decodeIfPresent(String.self, forKey: .offset) {
+                offset = s
+            } else if let i = try? container.decodeIfPresent(Int.self, forKey: .offset) {
+                offset = String(i)
+            } else {
+                offset = ""
+            }
+            if let i = try? container.decodeIfPresent(Int.self, forKey: .update_num) {
+                update_num = i
+            } else if let s = try? container.decodeIfPresent(String.self, forKey: .update_num) {
+                update_num = Int(s) ?? 0
+            } else {
+                update_num = 0
+            }
+            update_baseline = (try? container.decodeIfPresent(String.self, forKey: .update_baseline)) ?? ""
+            has_more = (try? container.decodeIfPresent(Bool.self, forKey: .has_more)) ?? false
         }
     }
 
     static func requestFollowsFeed(offset: String, page: Int) async throws -> DynamicFeedInfo {
         var param: [String: Any] = ["type": "all", "timezone_offset": "-480", "page": page]
-        if let offsetNum = Int(offset) {
-            param["offset"] = offsetNum
+        // offset 是服务端返回的分页 token，可能是非纯数字字符串；非空即原样回传，
+        // 避免只接受数字 offset 时翻页失效或反复请求第一页。
+        if !offset.isEmpty {
+            param["offset"] = offset
         }
         let res: DynamicFeedInfo = try await request(url: "https://api.bilibili.com/x/polymer/web-dynamic/v1/feed/all", parameters: param)
-        if res.videoFeeds.isEmpty, res.has_more {
+        // 本页全被过滤但还有更多时继续翻，但必须保证 offset 前进（非空且与上次不同），
+        // 否则异常 offset("" 或不变) 会无限重复请求同一页。
+        if res.videoFeeds.isEmpty, res.has_more, !res.offset.isEmpty, res.offset != offset {
             return try await requestFollowsFeed(offset: res.offset, page: page)
         }
         return res
@@ -150,10 +202,30 @@ struct DynamicFeedData: Codable, PlayableData, DisplayData {
                 }
 
                 struct Pgc: Codable, Hashable {
-                    let epid: Int
+                    let epid: Int?
                     let title: String?
                     let cover: URL?
                     let jump_url: URL?
+
+                    enum CodingKeys: String, CodingKey {
+                        case epid, title, cover, jump_url
+                    }
+
+                    // B站 API 有时把 epid 返回成 String 或缺失，非可选 Int 会让整条
+                    // 动态（乃至整页）解码失败。容忍 Int/String/null/missing。
+                    init(from decoder: Decoder) throws {
+                        let container = try decoder.container(keyedBy: CodingKeys.self)
+                        if let intVal = try? container.decodeIfPresent(Int.self, forKey: .epid) {
+                            epid = intVal
+                        } else if let strVal = try? container.decodeIfPresent(String.self, forKey: .epid) {
+                            epid = Int(strVal)
+                        } else {
+                            epid = nil
+                        }
+                        title = try container.decodeIfPresent(String.self, forKey: .title)
+                        cover = try container.decodeIfPresent(URL.self, forKey: .cover)
+                        jump_url = try container.decodeIfPresent(URL.self, forKey: .jump_url)
+                    }
                 }
             }
         }

--- a/BilibiliLive/Request/WebRequest.swift
+++ b/BilibiliLive/Request/WebRequest.swift
@@ -358,16 +358,19 @@ extension WebRequest {
             "played_time": currentTime,
         ]
 
-        if isBangumi {
+        // 番剧判定用超集：只要 isBangumi 或拿到了 epid/seasonId 就按番剧上报，避免
+        // 某些路径 isBangumi=false 却带 epid 时走普通视频分支，导致 B站不按番剧记历史。
+        let reportAsBangumi = isBangumi || (epid ?? 0) > 0 || (seasonId ?? 0) > 0
+        if reportAsBangumi {
             // 番剧类型标识
             parameters["type"] = 4
             parameters["sub_type"] = 1
 
             // 番剧ID
-            if let epid = epid {
+            if let epid = epid, epid > 0 {
                 parameters["epid"] = epid
             }
-            if let seasonId = seasonId {
+            if let seasonId = seasonId, seasonId > 0 {
                 parameters["sid"] = seasonId
             }
 
@@ -380,10 +383,19 @@ extension WebRequest {
             parameters["sub_type"] = 0
         }
 
+        // 历史上报此前 fire-and-forget，服务端非0/网络失败都不可见，无法诊断跨端不同步。
+        // 加 completion 日志：上报参数 + 返回 code/message，便于真机核对。
         requestJSON(method: .post,
                     url: EndPoint.heartbeat,
-                    parameters: parameters,
-                    complete: nil)
+                    parameters: parameters)
+        { result in
+            switch result {
+            case .success:
+                Logger.debug("[History] report ok aid=\(aid) cid=\(cid) t=\(currentTime) bangumi=\(reportAsBangumi) epid=\(epid ?? 0) sid=\(seasonId ?? 0)")
+            case let .failure(err):
+                Logger.warn("[History] report FAILED aid=\(aid) cid=\(cid) t=\(currentTime) bangumi=\(reportAsBangumi) epid=\(epid ?? 0) sid=\(seasonId ?? 0) err=\(err)")
+            }
+        }
     }
 
     static func requestUpSpaceVideo(mid: Int, page: Int, pageSize: Int = 50) async throws -> [UpSpaceReq.List.VListData] {


### PR DESCRIPTION
## 背景
两个用户报告的问题 + 上游 P0/P1 相关修复（策略：只挑相关、手工移植，不做全量合并；fork 已领先上游 197 提交、落后 171）。

## Bug1 — 顶部导航「关注」tab 点击报错（P0）
**根因**：关注动态流是异构数据，`Pgc.epid` 为非可选 `Int`，B站 API 有时返回 String/缺失 → 整个 `DynamicFeedInfo` 解码 throw → 关注页报错。

**修复**（`FollowsViewController.swift`）：
- `Pgc.epid` → `Int?` + 自定义 decoder 容错 Int/String/null/missing（对齐上游 #189）
- `DynamicFeedInfo` 逐条容错：`LossyItem` 跳过坏项而非整页失败；`update_num`/`offset`/`update_baseline`/`has_more` 柔性解码（对齐上游 #185 思路）
- `offset` 非空原样回传（支持非数字分页 token）；递归翻页加 offset 前进保护防死循环
- `videoFeeds` 过滤掉 epid 无效的纯 PGC 项；纯 PGC（aid=0）走 `create(epid:)`

## Bug2 — 播放历史 Apple TV 与手机不同步
**根因**：历史此前只在 `playerDidDismiss` 上报一次且 fire-and-forget。Apple TV 用户常直接后台/杀进程而非优雅退出播放器，弱网下单次上报静默失败 → 手机端看不到 ATV 观看记录。

**修复**：
- `BVideoPlayPlugin`：播放中周期心跳（`addPeriodicTimeObserver` 15s）+ pause/end/cleanup/dismiss/后台各 flush 一次；observer 生命周期化
- 切集/切码率 KVO cleanup 交叉污染守卫（`player === reportPlayer`），避免用新集 playData 上报旧 player 时间
- `reportWatchHistory` 加 completion 日志 + 番剧判定超集（`isBangumi||epid>0||seasonId>0`）
- `VideoDetailViewController` 番剧连播 seq 参数传播修复：补 `seasonId`/`epid`，番剧每集 aid 取 `$0.page`，避免续集串号/缺 ID

## 验证
- `xcodebuild -destination 'generic/platform=tvOS'` **BUILD SUCCEEDED**
- 关注页解码 **12 项极端输入**独立测试全过（epid Int/String/null/非法、坏项混合、全坏项、空数组、超长 title、顶层缺字段、offset 数字）
- 已部署真机 Apple TV 4K，待 UI/历史同步联调

## 复核
经 Codex 两轮对抗性复核（诊断阶段 + 最终 diff），修复其提出的全部 P1/P2（连播 aid 串号、插件清理交叉污染、纯 PGC 无效项、递归死循环保护）。

## 明确未纳入（记录）
- 上游 #177/#165/#199/#206/#758b373：跨 5-10 文件大改、fork 已重写，冲突高，本轮不动
- 历史读取端 `/x/v2/history` → cursor 端点迁移：若真机确认读取侧仍不同步再单独 PR
- #188：fork 已含（`observe(\.player, options: [.old,.new])`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)